### PR TITLE
[🌈 Feature] useIntersectionObserver 구현하기

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -45,4 +45,15 @@ module.exports = {
       },
     },
   },
+  // IntersectionObserverInit
+  overrides: [
+    // Typescript related rules
+    {
+      files: ['*.ts', '*.tsx'],
+      plugins: ['@typescript-eslint/eslint-plugin'],
+      parserOptions: {
+        project: ['./tsconfig.json'],
+      },
+    },
+  ],
 };

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,9 @@
+const useIntersectionObserver = (
+  targetRef: HTMLElement,
+  { root, rootMargin, threshold }: IntersectionObserverInit
+) => {
+  const option = { root, rootMargin, threshold };
+  return [targetRef, option];
+};
+
+export default useIntersectionObserver;

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,9 +1,32 @@
+import { RefObject, useEffect, useRef } from 'react';
+
+type CallbackType = IntersectionObserverCallback;
 const useIntersectionObserver = (
-  targetRef: HTMLElement,
+  targetRef: RefObject<Element>,
+  callback: CallbackType,
   { root, rootMargin, threshold }: IntersectionObserverInit
 ) => {
-  const option = { root, rootMargin, threshold };
-  return [targetRef, option];
+  const options = { root, rootMargin, threshold };
+  const callbackRef = useRef<CallbackType | null>(null);
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callbackRef]);
+
+  useEffect(() => {
+    if (callbackRef.current === null || targetRef.current === null) return;
+
+    const target = targetRef.current;
+    const observer = new IntersectionObserver(callbackRef.current, options);
+
+    observer.observe(target);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [targetRef, callbackRef]);
+
+  return [targetRef, callbackRef];
 };
 
 export default useIntersectionObserver;

--- a/src/hooks/useIntersectionObserver.ts
+++ b/src/hooks/useIntersectionObserver.ts
@@ -1,18 +1,12 @@
-import { RefObject, useEffect, useRef } from 'react';
+import { RefObject, useEffect } from 'react';
 
 type CallbackType = IntersectionObserverCallback;
 const useIntersectionObserver = (
   targetRef: RefObject<Element>,
-  callback: CallbackType,
+  callbackRef: RefObject<CallbackType>,
   { root, rootMargin, threshold }: IntersectionObserverInit
 ) => {
   const options = { root, rootMargin, threshold };
-  const callbackRef = useRef<CallbackType | null>(null);
-
-  useEffect(() => {
-    callbackRef.current = callback;
-  }, [callbackRef]);
-
   useEffect(() => {
     if (callbackRef.current === null || targetRef.current === null) return;
 
@@ -26,7 +20,7 @@ const useIntersectionObserver = (
     };
   }, [targetRef, callbackRef]);
 
-  return [targetRef, callbackRef];
+  return callbackRef;
 };
 
 export default useIntersectionObserver;

--- a/src/pages/MyPage/IndexPage.tsx
+++ b/src/pages/MyPage/IndexPage.tsx
@@ -1,11 +1,48 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
+import useIntersectionObserver from '../../hooks/useIntersectionObserver';
 
 const StyledMyPage = styled.div`
   height: 100%;
+  overflow-y: scroll;
 `;
 function MyPage() {
-  return <StyledMyPage>MyPage</StyledMyPage>;
+  const observerTargetRef = useRef(null);
+  const callbackRef = useRef<IntersectionObserverCallback | null>(null);
+  const [visible, setVisible] = useState(false);
+
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          setVisible(() => true);
+        } else if (visible) {
+          setVisible(() => false);
+        }
+      });
+    },
+    [visible]
+  );
+
+  useEffect(() => {
+    callbackRef.current = callback;
+  }, [callbackRef]);
+
+  useIntersectionObserver(observerTargetRef, callbackRef, {});
+
+  return (
+    <StyledMyPage>
+      {new Array(100).fill(0).map((_, idx) => (
+        /* eslint-disable-next-line react/no-array-index-key */
+        <div key={idx}>test! {JSON.stringify(visible)}</div>
+      ))}
+      <div ref={observerTargetRef}>hi {JSON.stringify(visible)}</div>
+      {new Array(100).fill(0).map((_, idx) => (
+        /* eslint-disable-next-line react/no-array-index-key */
+        <div key={idx}>test! {JSON.stringify(visible)}</div>
+      ))}
+    </StyledMyPage>
+  );
 }
 
 export default MyPage;

--- a/src/pages/MyPage/IndexPage.tsx
+++ b/src/pages/MyPage/IndexPage.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from '@emotion/styled';
 import useIntersectionObserver from '../../hooks/useIntersectionObserver';
 
@@ -11,22 +11,19 @@ function MyPage() {
   const callbackRef = useRef<IntersectionObserverCallback | null>(null);
   const [visible, setVisible] = useState(false);
 
-  const callback = useCallback(
-    (entries: IntersectionObserverEntry[]) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          setVisible(() => true);
-        } else {
-          setVisible(() => false);
-        }
-      });
-    },
-    [visible]
-  );
+  const callback = (entries: IntersectionObserverEntry[]) => {
+    entries.forEach((entry) => {
+      if (entry.isIntersecting) {
+        setVisible(() => true);
+      } else {
+        setVisible(() => false);
+      }
+    });
+  };
 
   useEffect(() => {
     callbackRef.current = callback;
-  }, [callbackRef]);
+  }, []);
 
   useIntersectionObserver(observerTargetRef, callbackRef, {});
 

--- a/src/pages/MyPage/IndexPage.tsx
+++ b/src/pages/MyPage/IndexPage.tsx
@@ -16,7 +16,7 @@ function MyPage() {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           setVisible(() => true);
-        } else if (visible) {
+        } else {
           setVisible(() => false);
         }
       });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ESNext",
+    "declaration": true,
     "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
     "allowJs": false,
@@ -17,5 +18,6 @@
     "jsx": "react-jsx"
   },
   "include": ["src"],
+  "exclude": ["node_modules"],
   "references": [{ "path": "./tsconfig.node.json" }]
 }


### PR DESCRIPTION
## 🚀 설명

`intersectionObserver API`를 쉽게 사용하기 위한 훅을 구현했다.

3개의 인자를 받는다.

1. `targetRef`: 엘리먼트를 담고 있다.
2. `callbackRef`: 콜백 함수를 담고 있다.

> 콜백을 `Ref`로 씌워준 이유는, 리렌더링 시에도 값을 유지하기 위함이다.

3. `options`: `intersectionObserver`의 2번째 인자로 들어갈 옵션들이다.

## 🔗 관련 이슈와 링크

closes #11 

## ⚠️ 논의해 볼 사항

특이한 경험이었다.
`lib.dom.d.ts`가 `eslint`에서 동작해야 하는데, 제대로 되지 않아서 `IntersectionObserverInit` 인터페이스를 인식하지 못했다.
원인을 찾기 위해 `typescript-eslint`의 documentation을 살펴보았더니, `project` 옵션을 명시해줘야 되었다.
따라서, 이를 적용해주었더니 잘 됐다!

## 🔑 참고할 만한 소스
[typescript-eslint documentation](https://github.com/typescript-eslint/typescript-eslint/tree/main/packages/parser#parseroptionsproject)
